### PR TITLE
bug/dont-display-endend-cues - FIX do not display ended cues (endTime = currentTime)

### DIFF
--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -155,7 +155,7 @@ shaka.ui.TextDisplayer = class {
     // Return true if the cue should be displayed at the current time point.
     const shouldCueBeDisplayed = (cue) => {
       return this.cues_.includes(cue) && this.isTextVisible_ &&
-             cue.startTime <= currentTime && cue.endTime >= currentTime;
+             cue.startTime <= currentTime && cue.endTime > currentTime;
     };
 
     // For each cue in the current cues map, if the cue's end time has passed,


### PR DESCRIPTION
Ended cues (endTime === currentTime) are not being detected as real ended cues, so they are returning true in 'shouldCueBeDisplayed'

Example:
First cue: endTime === currentTime 
Second cue: startTime === currentTime

Due to this, sometimes we have two active cues in dom (two 'spans' inside the 'div' shaka-text-container)