### PR TITLE
fix(net): prevent LL gaps by waiting for chunked fetch callbacks

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -141,6 +141,12 @@ shaka.net.HttpFetchPlugin = class {
         const contentLengthRaw = response.headers.get('Content-Length');
         const contentLength =
             contentLengthRaw ? parseInt(contentLengthRaw, 10) : 0;
+        let readerError = null;
+
+        let resolveReaderDone;
+        const readerDonePromise = new Promise((resolve) => {
+          resolveReaderDone = resolve;
+        });
 
         const start = (controller) => {
           const push = async () => {
@@ -152,13 +158,22 @@ shaka.net.HttpFetchPlugin = class {
               // it since real errors will be reported when we read the buffer
               // below.
               shaka.log.v1('error reading from stream', e.message);
+              resolveReaderDone();
               return;
             }
 
             if (!readObj.done) {
               loaded += readObj.value.byteLength;
               if (streamDataCallback) {
-                await streamDataCallback(readObj.value);
+                try {
+                  await streamDataCallback(readObj.value);
+                } catch (e) {
+                  readerError = e;
+                }
+                if (readerError) {
+                  resolveReaderDone();
+                  return;
+                }
               }
             }
 
@@ -178,6 +193,7 @@ shaka.net.HttpFetchPlugin = class {
             if (readObj.done) {
               goog.asserts.assert(!readObj.value,
                   'readObj should be unset when "done" is true.');
+              resolveReaderDone();
               controller.close();
             } else {
               controller.enqueue(readObj.value);
@@ -192,6 +208,15 @@ shaka.net.HttpFetchPlugin = class {
         // ReadableStream.
         new ReadableStream({start}); // eslint-disable-line no-new
         arrayBuffer = await response.arrayBuffer();
+        if (streamDataCallback) {
+          // Wait for any in-flight streamDataCallback to settle before
+          // resolving; otherwise StreamingEngine can advance while bytes
+          // are still mid-append.
+          await readerDonePromise;
+          if (readerError) {
+            throw readerError;
+          }
+        }
       }
     } catch (error) {
       if (abortStatus.canceled) {


### PR DESCRIPTION
## Problem

During Low Latency DASH playback we were observing frequent gap jumps in `gap_jumping_controller.js`. Diagnosis over four instrumented iterations narrowed the cause down to a race inside `shaka.net.HttpFetchPlugin.request_`:

- The HTTP response body is consumed by **two independent paths**:
  1. `response.clone().body.getReader()` — drives `streamDataCallback`, which incrementally appends bytes to the MSE `SourceBuffer` for Low Latency.
  2. `response.arrayBuffer()` — used as the final return value handed back to `StreamingEngine`.
- These two promises resolve independently. In Low Latency streams the last `streamDataCallback` (the final append) is frequently still in-flight when `arrayBuffer()` already resolves.
- When that happens, `request_` returns before the last chunk has been appended. `StreamingEngine` advances the iterator and considers the segment complete, but the trailing bytes that were delivered by the server and read by the reader were not yet appended to MSE.
- This can leave the media append pipeline behind the fetch pipeline, producing real buffered gaps once playback reaches the affected range.

Instrumented traces confirmed the pattern was **universal** across media segments under Low Latency: `arrayBuffer()` consistently resolved with exactly one callback still pending. The tail bytes that did not make it into the `SourceBuffer` were always the first portion of segment N+1 that the encoder emits at the end of the response of segment N (`styp + moof + partial-mdat`).

## Fix

Add a local one-shot promise (`readerDonePromise`) inside `request_` that is resolved when the reader-clone pipeline finishes (either via `readObj.done`, a `reader.read()` exception, or a `streamDataCallback` exception). After `arrayBuffer()` resolves, we now `await readerDonePromise` **only when `streamDataCallback` is provided** — so HEAD requests and non-LL requests are not affected. If a `streamDataCallback` threw, the captured error is re-thrown after the await so the failure is reported normally.

Key points:

- **Minimal surface area**: the fix is local to `request_`. Public APIs and the signature of `request_` are unchanged.
- **HEAD path unchanged**: the new await lives inside the existing `if (init.method != 'HEAD')` branch.
- **Non-LL path unchanged**: the await is gated by `if (streamDataCallback)`, so plain segment fetches without a streaming callback behave exactly as before.
- **Error semantics preserved**: instead of rejecting the promise from inside `streamDataCallback` (which could surface as an `unhandledrejection` on TV runtimes before the await is wired up), the error is captured in a local `readerError` and re-thrown after the await.
- **No clone-removal refactor**: `response.clone()` is still used. A more invasive refactor (consume `response.body` once, accumulate chunks for the final `arrayBuffer`) is intentionally out of scope.

## Why this is the correct latency cost

The added await is not extra latency — it is the latency that always belonged in the request. `request_` should not signal completion to `StreamingEngine` while bytes from the same response are still being appended to MSE. Returning early is precisely what produced the gaps. With Low Latency this added wait is the time it takes the final chunked append to settle, typically a few milliseconds.

## Out of scope (notes for future work)

- Aggressive ABR ramp-up is an amplifier of the race (each upshift aborts an in-flight segment and starts another), but is not the cause. Not touched in this PR.
- Replacing `response.clone()` + dual consumption with a single-reader accumulator is the cleaner structural fix and is left for a follow-up.

## Test plan

- [ ] Build debug bundle: `python3 build/build.py --name compiled +@complete -@ui --mode debug --force`
- [ ] Play the affected LL DASH stream for at least 5 minutes and verify recurring gap jumps no longer happen.
- [ ] Play a non-LL DASH or HLS stream and verify startup/playback are unchanged.
- [ ] Optional/manual: verify a `streamDataCallback` failure still propagates as a networking failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)